### PR TITLE
trim resource packages when reading from config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>in.vectorpro.dropwizard</groupId>
     <artifactId>dropwizard-swagger</artifactId>
 
-    <version>2.0.28-2</version>
+    <version>2.0.28-3</version>
     <name>Dropwizard Swagger v2.x and OpenAPI 3.x Integration</name>
     <url>https://github.com/Vect0rPro/dropwizard-swagger</url>
     <description>A simple way to document your REST APIs in Dropwizard using Swagger</description>

--- a/src/main/java/in/vectorpro/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/in/vectorpro/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -313,6 +313,6 @@ public class SwaggerBundleConfiguration {
         .prettyPrint(prettyPrint)
         .readAllResources(readAllResources)
         .ignoredRoutes(Arrays.stream(exclusions).collect(Collectors.toSet()))
-        .resourcePackages(Arrays.stream(resourcePackage.split(",")).collect(Collectors.toSet()));
+        .resourcePackages(Arrays.stream(resourcePackage.split(",")).map(String::trim).collect(Collectors.toSet()));
   }
 }


### PR DESCRIPTION
The following config would not work due to the space after comma:
```yml
swagger:
  resourcePackage: com.example.resources, com.example2.resources
```
we were forced to use:
```yml
swagger:
  resourcePackage: com.example.resources,com.example2.resources
```
This was due to the whitespace after the ",". The MR fixes that by trimming the package names before supplying them. Have tested locally